### PR TITLE
fix(seralization): Allow nativeEvents to be hacked around during seralization

### DIFF
--- a/src/client-options.ts
+++ b/src/client-options.ts
@@ -81,4 +81,6 @@ export interface ClientOptions {
    * Get the client id provided by the server
    */
   getClientId?: () => Promise<string>
+
+  proxyHack?: boolean
 }

--- a/src/reactotron-core-client.ts
+++ b/src/reactotron-core-client.ts
@@ -249,7 +249,7 @@ export class Client {
       deltaTime,
     }
 
-    const serializedMessage = serialize(fullMessage)
+    const serializedMessage = serialize(fullMessage, this.options.proxyHack)
 
     if (this.isReady) {
       // send this command

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -34,7 +34,7 @@ function getFunctionName(fn: any): string {
  *
  *  @param {any} source - The victim.
  */
-function serialize(source) {
+function serialize(source, proxyHack = false) {
   const stack = []
   const keys = []
 
@@ -63,6 +63,10 @@ function serialize(source) {
       // head shakers
       if (value === -0) return ZERO // eslint-disable-line
       if (value === "") return EMPTY_STRING
+
+      if (proxyHack && typeof value === "object" && value.nativeEvent) {
+        return value.nativeEvent
+      }
 
       // known types that have easy resolving
       switch (typeof value) {


### PR DESCRIPTION
The react SyntheticEvents are giving issues to serialization. This allows it to be "hacked" around