### PR TITLE
Remove warning on duplicate commands

### DIFF
--- a/src/reactotron-core-client.ts
+++ b/src/reactotron-core-client.ts
@@ -464,10 +464,6 @@ export class ReactotronImpl<ReactotronSubtype = ReactotronCore>
     // Make sure the command doesn't already exist
     const existingCommands = this.customCommands.filter(cc => cc.command === command)
     if (existingCommands.length > 0) {
-      console.warn(
-        `A custom command with the command "${command}" already exists. If you are on Android this is probably fine.`
-      )
-
       existingCommands.forEach(command => {
         console.log(command)
         this.customCommands = this.customCommands.filter(cc => cc.id !== command.id)


### PR DESCRIPTION
This makes reactotron-react-native compatible with the new Fast Refresh, as we'll be redefining any custom commands every refresh.

See https://twitter.com/jamonholmgren/status/1176693089345228801 including the gist:

https://gist.github.com/jamonholmgren/f6efbb8133661bdb86a068c4f15d75e6

