### PR TITLE
fix: Send state response only if there's any changes

### DIFF
--- a/src/plugins/state-responses.ts
+++ b/src/plugins/state-responses.ts
@@ -15,7 +15,8 @@ export default () => (reactotron: Reactotron) => {
       stateKeysResponse: (path, keys, valid = true) =>
         reactotron.send("state.keys.response", { path, keys, valid }),
 
-      stateValuesChange: changes => reactotron.send("state.values.change", { changes }),
+      stateValuesChange: changes =>
+        (changes.length > 0) && reactotron.send("state.values.change", { changes }),
 
       // sends the state backup over to the server
       stateBackupResponse: state => reactotron.send("state.backup.response", { state }),


### PR DESCRIPTION
Send state response only if there's any changes, the same manner of `sendSubscriptionsIfNeeded()` that `reactotron-redux` and `reactotron-mst` provides.