### PR TITLE
chore: add type `ReturnTypeReactotronUse`

### DIFF
--- a/src/reactotron-core-client.ts
+++ b/src/reactotron-core-client.ts
@@ -123,6 +123,17 @@ export interface ReactotronCore {
   repl?: (name: string, value: object | Function | string | number) => void
 }
 
+export interface ReturnTypeReactotronUse {
+  onCommand?: (args: { type: string; payload?: any }) => any
+  onConnect?: () => any
+  onDisconnect?: () => any
+  onPlugin?: (plugin: ReactotronCore) => void
+  /**
+   * These names are reserved:
+   *  `connect, configure, send, use, options, connected, plugins and socket.`
+   */
+  features?: Record<string, any>
+}
 export interface Reactotron<ReactotronSubtype = ReactotronCore> extends ReactotronCore {
   /**
    * Set the configuration options.
@@ -130,7 +141,9 @@ export interface Reactotron<ReactotronSubtype = ReactotronCore> extends Reactotr
   configure: (options?: ClientOptions) => Reactotron<ReactotronSubtype> & ReactotronSubtype
 
   use: (
-    pluginCreator?: (client: Reactotron<ReactotronSubtype> & ReactotronSubtype) => any
+    pluginCreator?: (
+      client: Reactotron<ReactotronSubtype> & ReactotronSubtype
+    ) => ReturnTypeReactotronUse
   ) => Reactotron<ReactotronSubtype> & ReactotronSubtype
 
   connect: () => Reactotron<ReactotronSubtype> & ReactotronSubtype
@@ -376,7 +389,9 @@ export class ReactotronImpl<ReactotronSubtype = ReactotronCore>
    * Adds a plugin to the system
    */
   use(
-    pluginCreator?: (client: Reactotron<ReactotronSubtype> & ReactotronSubtype) => any
+    pluginCreator?: (
+      client: Reactotron<ReactotronSubtype> & ReactotronSubtype
+    ) => ReturnTypeReactotronUse
   ): Reactotron<ReactotronSubtype> & ReactotronSubtype {
     // we're supposed to be given a function
     if (typeof pluginCreator !== "function") {


### PR DESCRIPTION
## Description
Improve return type of `pluginCreator` function to helps on creation of new plugins. The type is according to what is specified in readme.md. 

| before | now |
|--------|-----|
|<img width="987" alt="image" src="https://user-images.githubusercontent.com/17225358/179381034-185b737a-4a0a-44dd-8f6f-0d65cef9aae1.png">  |   <img width="1018" alt="image" src="https://user-images.githubusercontent.com/17225358/179381050-76629a67-65c4-437d-b301-7d2a0f453a24.png">      |